### PR TITLE
Implement Pairwise Distance

### DIFF
--- a/glomtf/pairwisedist.py
+++ b/glomtf/pairwisedist.py
@@ -1,6 +1,23 @@
 import tensorflow as tf
 
 def pairwise_dist(A, B):
+    """Write an algorithm that computes batched the p-norm distance between each pair of two collections of row vectors.
+
+    We use the euclidean distance metric.
+    For a matrix A [m, d] and a matrix B [n, d] we expect a matrix of
+    pairwise distances here D [m, n]
+
+    # Arguments:
+        A: A tf.Tensor object. The first matrix.
+        B: A tf.tensor object. The second matrix.
+
+    # Returns:
+        Calculate distance.
+
+    # Reference:
+        [scipy.spatial.distance.cdist](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html)
+        [tensorflow/tensorflow#30659](https://github.com/tensorflow/tensorflow/issues/30659)
+    """
 
     # squared norms of each row in A and B
     na = tf.reduce_sum(tf.square(A), 1)


### PR DESCRIPTION
Write an algorithm that computes batched the p-norm distance between each pair of two collections of row vectors. We use the euclidean distance metric. For a matrix A [m, d] and a matrix B [n, d] we expect a matrix of pairwise distances here D [m, n]

### Arguments:
- A: A tf.Tensor object. The first matrix.
- B: A tf.tensor object. The second matrix.

### Returns:
-  Calculate distance.

### Reference:
- [scipy.spatial.distance.cdist](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.distance.cdist.html)
- [tensorflow/tensorflow#30659](https://github.com/tensorflow/tensorflow/issues/30659)

---

Closes #4 